### PR TITLE
Add lockout feature for admins

### DIFF
--- a/htdocs/js/boxer.js
+++ b/htdocs/js/boxer.js
@@ -353,6 +353,14 @@ async function search_fetch(obj) {
                 td.innerHTML= "MFA not enabled on GitHub <sup>[3]</sup>";
             }
             tr.appendChild(td);
+            
+            // Admin links
+            td = document.createElement('td');
+            let a_lock = document.createElement('a');
+            a_lock.innerText = "lock account";
+            a_lock.href = `javascript:void(lock_account(${result.asf_id));`
+            td.appendChild(a_lock);
+            tr.appendChild(td);
 
             obj.appendChild(tr);
         }
@@ -395,6 +403,9 @@ function search_page(canvas, query) {
     tr.appendChild(th);
     th = document.createElement('th');
     th.innerText = "Status";
+    tr.appendChild(th);
+    th = document.createElement('th');
+    th.innerText = "Actions";
     tr.appendChild(th);
     table.appendChild(tr);
     let results = document.createElement('tbody');

--- a/htdocs/js/boxer.js
+++ b/htdocs/js/boxer.js
@@ -297,6 +297,16 @@ let search_timer = null;
 let search_query = "";
 let previous_query = "";
 
+async function lock_account(asf_id) {
+    let res = await GET('api/invite.json?lock=' + asf_id);
+    if (res.okay === true) {
+        alert("Account locked and unlinked");
+        location.reload();
+    } else {
+        alert(res.message);
+    }
+}
+
 async function search_fetch(obj) {
     if (search_query == previous_query) return;
     previous_query = search_query;
@@ -358,7 +368,7 @@ async function search_fetch(obj) {
             td = document.createElement('td');
             let a_lock = document.createElement('a');
             a_lock.innerText = "lock account";
-            a_lock.href = `javascript:void(lock_account(${result.asf_id));`
+            a_lock.href = `javascript:void(lock_account('${result.asf_id}'));`
             td.appendChild(a_lock);
             tr.appendChild(td);
 

--- a/server/endpoints/invite.py
+++ b/server/endpoints/invite.py
@@ -35,7 +35,6 @@ async def process(
                 person.save(server.database.client)
                 return {
                     "okay": True,
-                    "reauth": True,
                     "message": "unlinked from GitHub",
                 }
         return {


### PR DESCRIPTION
This adds a link to the search page, allowing admins to lock (forcibly unlink) accounts from GitHub.