### PR TITLE
Allow dots as repository name separators

### DIFF
--- a/server/plugins/repositories.py
+++ b/server/plugins/repositories.py
@@ -37,8 +37,10 @@ class Repository:
                 self.description = open(desc_file).read()
             except Exception:
                 print(f"Could not read description of {filepath}, setting to blank")
-
-        m = re.match(r"^(?:incubator-)?(empire-db|[^-.]+)-?.*(?:\.git)?$", self.filename)
+        # Determine project name from repo name:
+        # incubator-foo-bar.git -> foo
+        # httpd.blah.git -> httpd, etc.
+        m = re.match(r"^(?:incubator-)?(empire-db|[^-.]+)[-.]?.*(?:\.git)?$", self.filename)
         if m:
             self.project = m.group(1)
         else:


### PR DESCRIPTION
This change allows dots to function as separators for git repos as well as dashes. thus incubator-foo.bar.git will be treated the same as incubator-foo-bar.git.