### PR TITLE
Bump requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
-PyYAML~=5.4.1
+PyYAML~=6.0.1
 netaddr~=0.8.0
 asyncio~=3.4.3
-aiohttp~=3.6.2
+aiohttp>=3.9.4
 asfpy~=0.35
 multipart~=0.2.1
-requests~=2.24.0
+requests>=2.32.0
 aiosmtplib~=1.1.3
 netaddr~=0.8.0
 bonsai~=1.2.0


### PR DESCRIPTION
Tested on python 3.8 (gitbox) and 3.11 (home). Small hitches with 3.12, but that is not a worry at present, and should be fixed by the time we switch to that on gitbox.