### PR TITLE
Store GitHub details to LDAP and the Boxer database

### DIFF
--- a/server/endpoints/invite.py
+++ b/server/endpoints/invite.py
@@ -49,6 +49,7 @@ async def process(
             if person.asf_id == session.credentials.uid:
                 print(f"Unlinking GitHub login from user {person.asf_id}")
                 person.github_login = ""
+                # LDAP unlink will be implemented in a subsequent revision
                 person.save(server.database.client)
                 return {
                     "okay": True,

--- a/server/endpoints/invite.py
+++ b/server/endpoints/invite.py
@@ -17,6 +17,7 @@
 
 import plugins.basetypes
 import plugins.session
+import plugins.ldap
 import aiohttp
 
 """ GitHub org invite endpoint for Boxer"""
@@ -31,6 +32,19 @@ async def process(
         for person in server.data.people:
             if person.asf_id == user_to_lock:
                 print(f"Unlinking GitHub login from user {user_to_lock} (locked by {session.credentials.uid})")
+                try:
+                    async with plugins.ldap.LDAPClient(server.config.ldap) as lc:
+                        await lc.unset_user_github_primary(user_to_lock)
+                except RuntimeError as e:
+                    if "LDAP user not found" in str(e):
+                        return {
+                            "okay": False,
+                            "message": "Could not unlink - LDAP user not found",
+                        }
+                    return {
+                        "okay": False,
+                        "message": "Could not unlink - LDAP error",
+                    }
                 # Remove from sqlite
                 person.remove(server.database.client)
                 # Remove from server cache
@@ -48,7 +62,21 @@ async def process(
         for person in server.data.people:
             if person.asf_id == session.credentials.uid:
                 print(f"Unlinking GitHub login from user {person.asf_id}")
+                try:
+                    async with plugins.ldap.LDAPClient(server.config.ldap) as lc:
+                        await lc.unset_user_github_primary(session.credentials.uid)
+                except RuntimeError as e:
+                    if "LDAP user not found" in str(e):
+                        return {
+                            "okay": False,
+                            "message": "Could not unlink - LDAP user not found",
+                        }
+                    return {
+                        "okay": False,
+                        "message": "Could not unlink - LDAP error",
+                    }
                 person.github_login = ""
+                person.github_id = 0
                 # LDAP unlink will be implemented in a subsequent revision
                 person.save(server.database.client)
                 return {
@@ -66,6 +94,7 @@ async def process(
                 if person.github_login == session.credentials.github_login:
                     print(f"Removing stale GitHub login from user {person.asf_id}")
                     person.github_login = ""
+                    person.github_id = 0
                     person.save(server.database.client)
                     break
         return {

--- a/server/plugins/ldap.py
+++ b/server/plugins/ldap.py
@@ -133,7 +133,7 @@ class LDAPClient:
     async def set_user_github_primary(self, uid: str, username: str, user_id: int):
         if not self.connection:
             raise RuntimeError("LDAP Not connected")
-        dn = f"uid={uid},{self.config.userbase}"
+        dn = self.config.userbase % uid
         rv = await self.connection.search(
             dn, bonsai.LDAPSearchScope.BASE, None, [
                 "objectClass",

--- a/server/plugins/ldap.py
+++ b/server/plugins/ldap.py
@@ -137,21 +137,21 @@ class LDAPClient:
         rv = await self.connection.search(
             dn, bonsai.LDAPSearchScope.BASE, None, [
                 "objectClass",
-                "githubPrimaryUsername",
-                "githubPrimaryUserID",
+                "asf-githubNumericID",
+                "asf-githubStringID",
             ]
         )
         if (not rv) or (len(rv) == 0):
             raise RuntimeError(f"LDAP user not found: {dn}")
         entry = rv[0]
-        # Ensure asf-committer OC exists to write the githubPrimary* attributes
+        # Ensure asf-committer OC exists to write the asf-github*ID attributes
         if "objectClass" in entry:
             if not any((oc.lower() == "asf-committer") for oc in entry["objectClass"]):
                 entry["objectClass"].append("asf-committer")
         else:
             entry["objectClass"] = ["asf-committer"]
-        entry["githubPrimaryUsername"] = [str(username)]
-        entry["githubPrimaryUserID"] = [int(user_id)]
+        entry["asf-githubNumericID"] = [int(user_id)]
+        entry["asf-githubStringID"] = [str(username)]
         await entry.modify()
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):

--- a/server/plugins/projects.py
+++ b/server/plugins/projects.py
@@ -10,6 +10,7 @@ class Committer:
         document = {
             "asfid": self.asf_id,
             "githubid": self.github_login,
+            "githubnum": self.github_id,
             "mfa": 1 if self.github_mfa else 0,
             "updated": datetime.datetime.now(),
         }
@@ -33,10 +34,12 @@ class Committer:
             row = None
         if row:
             self.github_login = row["githubid"]
+            self.github_id = row.get("githubnum")
             self.github_mfa = bool(row["mfa"])
             self.real_name = ""
         else:
             self.github_login = None
+            self.github_id = None
             self.github_mfa = False
             self.real_name = ""
 


### PR DESCRIPTION
First draft of the resolution to [INFRA-25672](https://issues.apache.org/jira/browse/INFRA-25672).

When a user links their GitHub account, this code adds the `githubPrimaryUsername` string and `githubPrimaryUserID` integer values to LDAP. It then adds the numeric GitHub ID of the user as a `githubnum` integer to the Boxer database, in addition to the current `githubid` text value.

Requires an LDAP schema alteration to add `githubPrimaryUsername` and `githubPrimaryUserID` as SINGLE-VALUE attributes. Could add a new AUX OC with `MUST ( githubPrimaryUsername $ githubPrimaryUserID )`, but might be better to keep it simple and add to the existing `asf-committer` AUX OC.

Requires a one time schema alteration to the Boxer database:

```
ALTER TABLE ids ADD COLUMN githubnum INTEGER;
```

Additional checks and constraints could also be added.

Does not yet implement changes to LDAP and the Boxer database upon GitHub account unlinking. Review of what is currently here would be appreciated.